### PR TITLE
[FEAT] diagnosis 도메인 엔터티 생성

### DIFF
--- a/src/main/java/com/example/SeaTea/domain/diagnosis/entity/DiagnosisResponse.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/entity/DiagnosisResponse.java
@@ -24,7 +24,7 @@ public class DiagnosisResponse extends BaseEntity {
     @Column(name = "item_code", nullable = false)
     private String itemCode;
 
-    //질문에 대한 사용자의 응답 ex) A, B, C / ture / 100 등
+    //질문에 대한 사용자의 응답 ex) A, B, C / true / 100 등
     @Column(name = "answer_code", nullable = false)
     private String answerCode;
 }

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/entity/DiagnosisResponse.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/entity/DiagnosisResponse.java
@@ -1,0 +1,30 @@
+package com.example.SeaTea.domain.diagnosis.entity;
+
+import com.example.SeaTea.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "diagnosis_response")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class DiagnosisResponse extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    //어떤 세션에 대한 응답인지 연결
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private DiagnosisSession session;
+
+    //상세진단 또는 키워드의 일련번호 ex) Q01 or KW01
+    @Column(name = "item_code", nullable = false)
+    private String itemCode;
+
+    //질문에 대한 사용자의 응답 ex) A, B, C / ture / 100 등
+    @Column(name = "answer_code", nullable = false)
+    private String answerCode;
+}

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/entity/DiagnosisSession.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/entity/DiagnosisSession.java
@@ -1,0 +1,33 @@
+package com.example.SeaTea.domain.diagnosis.entity;
+
+import com.example.SeaTea.domain.diagnosis.enums.Mode;
+import com.example.SeaTea.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "diagnosis_session")
+public class DiagnosisSession extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+//    //한 사용자가 여러번 진단이 가능.
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "member_id" ,nullable = false )
+//    private Member member;
+
+    //진단 결과 유형
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "type_id" , nullable = false )
+    private TastingNoteType type;
+
+    //진단 방법 (상세 or 간단)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Mode mode;
+}

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/entity/TastingNoteType.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/entity/TastingNoteType.java
@@ -1,0 +1,32 @@
+package com.example.SeaTea.domain.diagnosis.entity;
+
+import com.example.SeaTea.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Table(name = "tasting_note_type")
+public class TastingNoteType extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false,unique = true)
+    private String code; //ex) FLORAL
+
+    @Column(nullable = false, name = "display_name")
+    private String displayName; //ex) Floral
+
+    @Column
+    private String subtitle; //ex) 감각적인 영감의 휴식
+
+    @Column
+    private String description; //ex) 혼자만의 시간을 선호하지만..
+
+    @Column(name = "image_url")
+    private String imageUrl; //ex) 전용 이미지
+}

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/enums/Mode.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/enums/Mode.java
@@ -1,0 +1,6 @@
+package com.example.SeaTea.domain.diagnosis.enums;
+
+public enum Mode {
+    DETAIL,
+    QUICK
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,16 +11,16 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-    jpa:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
       hibernate:
-        ddl-auto: update
-      show-sql: true
-      properties:
-        hibernate:
-          format_sql: true
-          dialect: org.hibernate.dialect.MySQL8Dialect
-          jdbc:
-            time_zone: Asia/Seoul
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        jdbc:
+          time_zone: Asia/Seoul
 
 server:
   port: ${SERVER_PORT:8080}


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

feat/2-diagnosis-entity

## 🔑 주요 내용

- 주요 변경점 간단 요약
- 엔터티 3개와 enum인 Mode 추가.
- 아직 멤버 엔터티가 없어서 주석처리해뒀습니다!

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added foundational database entities to support the diagnosis workflow: sessions, responses, and tasting note types.
  * Introduced selectable diagnosis modes (DETAIL and QUICK).

* **Chores**
  * Enabled Hibernate auto schema updates, SQL formatting, MySQL 8 dialect, and timezone support for smoother DB operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->