### PR TITLE
[FIX] 간단진단 컴파일에러, 키워드 validate

### DIFF
--- a/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisQuickConverter.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisQuickConverter.java
@@ -52,7 +52,7 @@ public class DiagnosisQuickConverter {
             Map<TastingNoteTypeCode, Integer> scores
     ) {
         return DiagnosisQuickResponseDTO.builder()
-                .resultType(resultType)
+                .resultTypeCode(resultType)
                 .keywords(keywords)
                 .scores(scores)
                 .build();

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/dto/request/DiagnosisQuickRequestDTO.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/dto/request/DiagnosisQuickRequestDTO.java
@@ -16,8 +16,8 @@ import java.util.List;
 @Getter
 public class DiagnosisQuickRequestDTO {
 
-    @NotNull(message = "keywords는 필수입니다.")
+    @NotNull(message = "keywords는 필수입니다.") //리스트 자체가 null인지 확인하는거지, 요소는 검증x
     @Size(min = 3, max = 3, message = "keywords는 정확히 3개를 선택해야 합니다.")
-    private List<QuickKeyword> keywords;
+    private List<@NotNull QuickKeyword> keywords; //각 요소도 null 불가
 
 }


### PR DESCRIPTION
컴파일에러 
dto와 converter의 필드명 불일치 수정

간단진단의 요청 dto의 리스트 요소 Null 가능성 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 진단 응답 필드명이 수정되었습니다.
  * 진단 요청 시 입력 데이터의 유효성 검사를 강화하여 데이터 무결성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->