### PR TITLE
[FEAT] 진단결과 조회 API, 진단이력 조회 API 구현

### DIFF
--- a/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
@@ -3,15 +3,20 @@ package com.example.SeaTea.domain.diagnosis.controller;
 import com.example.SeaTea.domain.diagnosis.dto.request.DiagnosisDetailRequestDTO;
 import com.example.SeaTea.domain.diagnosis.dto.response.DiagnosisDetailResponseDTO;
 import com.example.SeaTea.domain.diagnosis.dto.request.DiagnosisQuickRequestDTO;
+import com.example.SeaTea.domain.diagnosis.dto.response.DiagnosisHistoryResponseDTO;
 import com.example.SeaTea.domain.diagnosis.dto.response.DiagnosisQuickResponseDTO;
+import com.example.SeaTea.domain.diagnosis.dto.response.DiagnosisResultResponseDTO;
 import com.example.SeaTea.domain.diagnosis.service.DiagnosisQuickService;
 import com.example.SeaTea.domain.diagnosis.service.DiagnosisDetailService;
+import com.example.SeaTea.domain.diagnosis.service.DiagnosisResultService;
 import com.example.SeaTea.domain.member.entity.Member;
 import com.example.SeaTea.domain.member.repository.MemberRepository;
 import com.example.SeaTea.global.apiPayLoad.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +26,7 @@ public class DiagnosisController {
     private final DiagnosisDetailService diagnosisDetailService;
     private final MemberRepository memberRepository;
     private final DiagnosisQuickService diagnosisQuickService;
+    private final DiagnosisResultService diagnosisResultService;
 
     // 임시 테스트용: memberId로 멤버 조회 후 진단 제출
     @PostMapping("/detail/test")
@@ -68,4 +74,35 @@ public class DiagnosisController {
 //    ) {
 //        return ApiResponse.onSuccess(diagnosisQuickService.submitQuickDiagnosis(member, req));
 //    }
+
+    @GetMapping("/me/test")
+    public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResultTest(
+            @RequestParam Long memberId
+    ) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("member not found: " + memberId));
+        return ApiResponse.onSuccess(diagnosisResultService.getMyLatestResult(member));
+    }
+
+    @GetMapping("/me/history/test")
+    public ApiResponse<List<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistoryTest(
+            @RequestParam Long memberId
+    ) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("member not found: " + memberId));
+        return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member));
+    }
+    // @GetMapping("/me")
+    // public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResult(
+    //         @AuthenticationPrincipal Member member
+    // ) {
+    //     return ApiResponse.onSuccess(diagnosisResultService.getMyLatestResult(member));
+    // }
+    //
+    // @GetMapping("/me/history")
+    // public ApiResponse<List<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistory(
+    //         @AuthenticationPrincipal Member member
+    // ) {
+    //     return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member));
+    // }
 }

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
@@ -92,6 +92,8 @@ public class DiagnosisController {
                 .orElseThrow(() -> new IllegalArgumentException("member not found: " + memberId));
         return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member));
     }
+
+    //나중에 인증붙으면 교체
     // @GetMapping("/me")
     // public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResult(
     //         @AuthenticationPrincipal Member member

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
@@ -12,6 +12,8 @@ import com.example.SeaTea.domain.diagnosis.service.DiagnosisResultService;
 import com.example.SeaTea.domain.member.entity.Member;
 import com.example.SeaTea.domain.member.repository.MemberRepository;
 import com.example.SeaTea.global.apiPayLoad.ApiResponse;
+import com.example.SeaTea.global.exception.GeneralException;
+import com.example.SeaTea.global.status.ErrorStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -28,6 +30,11 @@ public class DiagnosisController {
     private final DiagnosisQuickService diagnosisQuickService;
     private final DiagnosisResultService diagnosisResultService;
 
+    private Member findMemberOrThrow(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST));
+    }
+
     // 임시 테스트용: memberId로 멤버 조회 후 진단 제출
     @PostMapping("/detail/test")
     public ApiResponse<DiagnosisDetailResponseDTO> submitDetailDiagnosisTest(
@@ -35,9 +42,7 @@ public class DiagnosisController {
             @RequestBody @Valid DiagnosisDetailRequestDTO req
     ) {
         System.out.println(">>> diagnosis detail test called"); //호출 확인용
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("member not found: " + memberId));
-        //없는 멤버면 에러
+        Member member = findMemberOrThrow(memberId);
 
         return ApiResponse.onSuccess(diagnosisDetailService.submitDetailDiagnosis(member, req));
         //성공이면 200 OK, DTO를 JSON으로 반환
@@ -51,8 +56,7 @@ public class DiagnosisController {
     ) {
         System.out.println(">>> diagnosis quick test called"); // 호출 확인용
 
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("member not found: " + memberId));
+        Member member = findMemberOrThrow(memberId);
 
         return ApiResponse.onSuccess(diagnosisQuickService.submitQuickDiagnosis(member, req));
     }
@@ -79,8 +83,7 @@ public class DiagnosisController {
     public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResultTest(
             @RequestParam Long memberId
     ) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("member not found: " + memberId));
+        Member member = findMemberOrThrow(memberId);
         return ApiResponse.onSuccess(diagnosisResultService.getMyLatestResult(member));
     }
 
@@ -88,8 +91,7 @@ public class DiagnosisController {
     public ApiResponse<List<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistoryTest(
             @RequestParam Long memberId
     ) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("member not found: " + memberId));
+        Member member = findMemberOrThrow(memberId);
         return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member));
     }
 

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
@@ -17,8 +17,10 @@ import com.example.SeaTea.global.status.ErrorStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 
 @RestController
 @RequiredArgsConstructor
@@ -79,6 +81,7 @@ public class DiagnosisController {
 //        return ApiResponse.onSuccess(diagnosisQuickService.submitQuickDiagnosis(member, req));
 //    }
 
+    //내 최신 진단 조회
     @GetMapping("/me/test")
     public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResultTest(
             @RequestParam Long memberId
@@ -87,12 +90,22 @@ public class DiagnosisController {
         return ApiResponse.onSuccess(diagnosisResultService.getMyLatestResult(member));
     }
 
+    //과거 진단내역 조회 (슬라이스로 페이징)
     @GetMapping("/me/history/test")
-    public ApiResponse<List<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistoryTest(
-            @RequestParam Long memberId
+    public ApiResponse<Slice<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistoryTest(
+            @RequestParam Long memberId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
     ) {
         Member member = findMemberOrThrow(memberId);
-        return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member));
+
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member, pageable));
     }
 
     //나중에 인증붙으면 교체
@@ -104,9 +117,16 @@ public class DiagnosisController {
     // }
     //
     // @GetMapping("/me/history")
-    // public ApiResponse<List<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistory(
-    //         @AuthenticationPrincipal Member member
+    // public ApiResponse<Slice<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistory(
+    //         @AuthenticationPrincipal Member member,
+    //         @RequestParam(defaultValue = "0") int page,
+    //         @RequestParam(defaultValue = "10") int size
     // ) {
-    //     return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member));
+    //     Pageable pageable = PageRequest.of(
+    //             page,
+    //             size,
+    //             Sort.by(Sort.Direction.DESC, "createdAt")
+    //     );
+    //     return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member, pageable));
     // }
 }

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisDetailConverter.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisDetailConverter.java
@@ -84,7 +84,7 @@ public class DiagnosisDetailConverter {
         // Step1 응답 누락은 데이터 정합성 문제이므로 요청 오류로 처리
         if (q1 == null || q2 == null || q3 == null || q4 == null || q4.isEmpty()) {
             throw new DiagnosisException(DiagnosisErrorStatus._INVALID_STEP);
-        }
+        } //즉, step2요청이 들어왔을 때, DB에 step1 응답이 하나라도 누락되어 있으면 예외발생.
 
         return new Step1Answers(q1, q2, q3, q4);
     }

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisDetailConverter.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisDetailConverter.java
@@ -1,5 +1,7 @@
 package com.example.SeaTea.domain.diagnosis.converter;
 
+import com.example.SeaTea.domain.diagnosis.exception.DiagnosisException;
+import com.example.SeaTea.domain.diagnosis.exception.DiagnosisErrorStatus;
 import com.example.SeaTea.domain.diagnosis.dto.request.DiagnosisDetailRequestDTO;
 import com.example.SeaTea.domain.diagnosis.entity.DiagnosisResponse;
 import com.example.SeaTea.domain.diagnosis.entity.DiagnosisSession;
@@ -81,7 +83,7 @@ public class DiagnosisDetailConverter {
 
         // Step1 응답 누락은 데이터 정합성 문제이므로 요청 오류로 처리
         if (q1 == null || q2 == null || q3 == null || q4 == null || q4.isEmpty()) {
-            throw new IllegalArgumentException("Step1 answers are missing for this session.");
+            throw new DiagnosisException(DiagnosisErrorStatus._INVALID_STEP);
         }
 
         return new Step1Answers(q1, q2, q3, q4);

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisQuickConverter.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisQuickConverter.java
@@ -5,6 +5,8 @@ import com.example.SeaTea.domain.diagnosis.entity.DiagnosisResponse;
 import com.example.SeaTea.domain.diagnosis.entity.DiagnosisSession;
 import com.example.SeaTea.domain.diagnosis.enums.QuickKeyword;
 import com.example.SeaTea.domain.diagnosis.enums.TastingNoteTypeCode;
+import com.example.SeaTea.domain.diagnosis.exception.DiagnosisException;
+import com.example.SeaTea.domain.diagnosis.exception.DiagnosisErrorStatus;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,15 +22,27 @@ public class DiagnosisQuickConverter {
             DiagnosisSession session,
             List<QuickKeyword> keywords
     ) {
-        List<DiagnosisResponse> responses = new ArrayList<>();
+        if (session == null) {
+            throw new DiagnosisException(
+                DiagnosisErrorStatus._INVALID_STEP
+            );
+        }
 
         if (keywords == null || keywords.isEmpty()) {
-            return responses;
+            throw new DiagnosisException(
+                DiagnosisErrorStatus._INVALID_STEP
+            );
         }
+
+        List<DiagnosisResponse> responses = new ArrayList<>();
 
         for (int i = 0; i < keywords.size(); i++) {
             QuickKeyword keyword = keywords.get(i);
-            if (keyword == null) continue;
+            if (keyword == null) {
+                throw new DiagnosisException(
+                    DiagnosisErrorStatus._INVALID_STEP
+                );
+            }
 
             responses.add(
                     DiagnosisResponse.builder()

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisQuickConverter.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisQuickConverter.java
@@ -25,13 +25,13 @@ public class DiagnosisQuickConverter {
         if (session == null) {
             throw new DiagnosisException(
                 DiagnosisErrorStatus._INVALID_STEP
-            );
+            );//세션이 비어있는데 컨버터 호출
         }
 
         if (keywords == null || keywords.isEmpty()) {
             throw new DiagnosisException(
                 DiagnosisErrorStatus._INVALID_STEP
-            );
+            );//키워드를 아예 안보냄
         }
 
         List<DiagnosisResponse> responses = new ArrayList<>();
@@ -41,7 +41,7 @@ public class DiagnosisQuickConverter {
             if (keyword == null) {
                 throw new DiagnosisException(
                     DiagnosisErrorStatus._INVALID_STEP
-                );
+                );//키워드 중간에 null이 껴 있음.
             }
 
             responses.add(

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisQuickConverter.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisQuickConverter.java
@@ -52,7 +52,7 @@ public class DiagnosisQuickConverter {
             Map<TastingNoteTypeCode, Integer> scores
     ) {
         return DiagnosisQuickResponseDTO.builder()
-                .resultType(resultType)
+                .resultTypeCode(resultType)
                 .keywords(keywords)
                 .scores(scores)
                 .build();

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/dto/response/DiagnosisHistoryResponseDTO.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/dto/response/DiagnosisHistoryResponseDTO.java
@@ -1,0 +1,41 @@
+package com.example.SeaTea.domain.diagnosis.dto.response;
+
+import com.example.SeaTea.domain.diagnosis.entity.DiagnosisSession;
+import com.example.SeaTea.domain.diagnosis.entity.TastingNoteType;
+import com.example.SeaTea.domain.diagnosis.enums.Mode;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+
+ // 나의 진단 히스토리 조회 응답 DTO
+ // 마이페이지 > 과거 진단 결과 리스트용
+@Getter
+@Builder
+@AllArgsConstructor
+public class DiagnosisHistoryResponseDTO {
+
+    private Long sessionId;            // 진단 세션 ID
+    private Mode mode;                 // QUICK / DETAIL
+    private LocalDateTime createdAt;   // 진단 완료 시각
+
+    private String typeCode;           // ex) FLORAL
+    private String displayName;        // ex) Floral
+    private String imageUrl;           // 결과 이미지 URL
+
+
+    //DiagnosisSession 엔티티 → 히스토리 응답 DTO 변환
+    public static DiagnosisHistoryResponseDTO from(DiagnosisSession session) {
+        TastingNoteType type = session.getType(); // type != null (조회 조건으로 보장)
+
+        return DiagnosisHistoryResponseDTO.builder()
+                .sessionId(session.getId())
+                .mode(session.getMode())
+                .createdAt(session.getCreatedAt())
+                .typeCode(type.getCode())
+                .displayName(type.getDisplayName())
+                .imageUrl(type.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/dto/response/DiagnosisResultResponseDTO.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/dto/response/DiagnosisResultResponseDTO.java
@@ -1,0 +1,33 @@
+package com.example.SeaTea.domain.diagnosis.dto.response;
+
+import com.example.SeaTea.domain.diagnosis.entity.TastingNoteType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 나의 진단 결과(최근 1건) 조회 응답 DTO
+ * - 홈/마이페이지 상단에 노출되는 결과 카드용
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class DiagnosisResultResponseDTO {
+
+    private String typeCode;      // ex) FLORAL
+    private String displayName;   // ex) Floral
+    private String subtitle;      // ex) 감각적인 영감의 휴식
+    private String description;   // 상세 설명
+    private String imageUrl;      // 결과 이미지 URL
+
+    //TastingNoteType 엔티티 → 결과 응답 DTO 변환
+    public static DiagnosisResultResponseDTO from(TastingNoteType type) {
+        return DiagnosisResultResponseDTO.builder()
+                .typeCode(type.getCode())
+                .displayName(type.getDisplayName())
+                .subtitle(type.getSubtitle())
+                .description(type.getDescription())
+                .imageUrl(type.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/exception/DiagnosisErrorStatus.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/exception/DiagnosisErrorStatus.java
@@ -1,0 +1,59 @@
+package com.example.SeaTea.domain.diagnosis.exception;
+
+import com.example.SeaTea.global.code.BaseErrorCode;
+import com.example.SeaTea.global.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum DiagnosisErrorStatus implements BaseErrorCode {
+
+    _NO_COMPLETED_DIAGNOSIS(
+            HttpStatus.NOT_FOUND,
+            "DIAGNOSIS404",
+            "완료된 진단 결과가 없습니다."
+    ),
+
+    _INVALID_STEP(
+            HttpStatus.BAD_REQUEST,
+            "DIAGNOSIS400",
+            "잘못된 진단 단계입니다."
+    ),
+
+    _SESSION_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "DIAGNOSIS404_1",
+            "진단 세션을 찾을 수 없습니다."
+    ),
+
+    _TYPE_NOT_FOUND(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "DIAGNOSIS500_1",
+            "결과 타입 정보를 찾을 수 없습니다."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/exception/DiagnosisErrorStatus.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/exception/DiagnosisErrorStatus.java
@@ -24,13 +24,13 @@ public enum DiagnosisErrorStatus implements BaseErrorCode {
 
     _SESSION_NOT_FOUND(
             HttpStatus.NOT_FOUND,
-            "DIAGNOSIS404_1",
+            "DIAGNOSIS404",
             "진단 세션을 찾을 수 없습니다."
     ),
 
-    _TYPE_NOT_FOUND(
+    _TYPE_NOT_FOUND( //타입DB에 값이 안들어가 있음.
             HttpStatus.INTERNAL_SERVER_ERROR,
-            "DIAGNOSIS500_1",
+            "DIAGNOSIS500",
             "결과 타입 정보를 찾을 수 없습니다."
     );
 

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/exception/DiagnosisException.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/exception/DiagnosisException.java
@@ -1,0 +1,10 @@
+package com.example.SeaTea.domain.diagnosis.exception;
+
+import com.example.SeaTea.global.code.BaseErrorCode;
+import com.example.SeaTea.global.exception.GeneralException;
+
+public class DiagnosisException extends GeneralException {
+    public DiagnosisException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/repository/DiagnosisSessionRepository.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/repository/DiagnosisSessionRepository.java
@@ -1,7 +1,10 @@
 package com.example.SeaTea.domain.diagnosis.repository;
 
 import com.example.SeaTea.domain.diagnosis.entity.DiagnosisSession;
+import com.example.SeaTea.domain.diagnosis.entity.TastingNoteType;
 import com.example.SeaTea.domain.member.entity.Member;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -12,9 +15,9 @@ public interface DiagnosisSessionRepository extends JpaRepository<DiagnosisSessi
     // 특정 세션 + 멤버 소유 검증용
     Optional<DiagnosisSession> findByIdAndMemberId(Long id, Long memberId);
 
-    // 나의 진단 히스토리 조회 (완료된 세션 전체, 최신순)
-    List<DiagnosisSession> findByMemberAndTypeIsNotNullOrderByCreatedAtDesc(Member member);
-
     // 나의 최신 진단 결과 1건 조회 (완료된 세션 중 최신)
     Optional<DiagnosisSession> findTopByMemberAndTypeIsNotNullOrderByCreatedAtDesc(Member member);
+
+    // 나의 진단 히스토리 조회 (완료된 세션 전체, 최신순)
+    Slice<DiagnosisSession> findByMemberAndTypeIsNotNullOrderByCreatedAtDesc(Member member, Pageable pageable);
 }

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/repository/DiagnosisSessionRepository.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/repository/DiagnosisSessionRepository.java
@@ -1,10 +1,20 @@
 package com.example.SeaTea.domain.diagnosis.repository;
 
 import com.example.SeaTea.domain.diagnosis.entity.DiagnosisSession;
+import com.example.SeaTea.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DiagnosisSessionRepository extends JpaRepository<DiagnosisSession, Long> {
+
+    // 특정 세션 + 멤버 소유 검증용
     Optional<DiagnosisSession> findByIdAndMemberId(Long id, Long memberId);
+
+    // 나의 진단 히스토리 조회 (완료된 세션 전체, 최신순)
+    List<DiagnosisSession> findByMemberAndTypeIsNotNullOrderByCreatedAtDesc(Member member);
+
+    // 나의 최신 진단 결과 1건 조회 (완료된 세션 중 최신)
+    Optional<DiagnosisSession> findTopByMemberAndTypeIsNotNullOrderByCreatedAtDesc(Member member);
 }

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisDetailService.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisDetailService.java
@@ -160,7 +160,8 @@ public class DiagnosisDetailService {
 
         // 5) 결과 타입 엔티티 조회 후 세션에 저장
         TastingNoteType finalType = tastingNoteTypeRepository.findByCode(finalCodeStr)
-                .orElseThrow(() -> new DiagnosisException(DiagnosisErrorStatus._TYPE_NOT_FOUND));//타입 조회 실패
+                .orElseThrow(() -> new DiagnosisException(DiagnosisErrorStatus._TYPE_NOT_FOUND));
+        //타입 조회 실패 -> 결과는 잘 나왔는데 DB에 해당 타입이 없음 -> 서버문제
 
         // 이미 조회된 session 엔티티를 업데이트(더티체킹)
         session.updateType(finalType);

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisQuickService.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisQuickService.java
@@ -9,6 +9,8 @@ import com.example.SeaTea.domain.diagnosis.entity.TastingNoteType;
 import com.example.SeaTea.domain.diagnosis.enums.Mode;
 import com.example.SeaTea.domain.diagnosis.enums.QuickKeyword;
 import com.example.SeaTea.domain.diagnosis.enums.TastingNoteTypeCode;
+import com.example.SeaTea.domain.diagnosis.exception.DiagnosisException;
+import com.example.SeaTea.domain.diagnosis.exception.DiagnosisErrorStatus;
 import com.example.SeaTea.domain.diagnosis.repository.DiagnosisResponseRepository;
 import com.example.SeaTea.domain.diagnosis.repository.DiagnosisSessionRepository;
 import com.example.SeaTea.domain.diagnosis.repository.TastingNoteTypeRepository;
@@ -42,6 +44,9 @@ public class DiagnosisQuickService {
         diagnosisSessionRepository.save(session);
 
         List<QuickKeyword> keywords = req.getKeywords();
+        if (keywords == null || keywords.size() != 3) {
+            throw new DiagnosisException(DiagnosisErrorStatus._INVALID_STEP);
+        }//잘못된 진단단계 예외
 
         // 2) 응답 저장 (KW01~KW03)
         List<DiagnosisResponse> responses =
@@ -71,8 +76,8 @@ public class DiagnosisQuickService {
         TastingNoteType typeEntity =
                 tastingNoteTypeRepository.findByCode(resultCode.name())
                         .orElseThrow(() ->
-                                new IllegalStateException("TastingNoteType not found: " + resultCode)
-                        );
+                                new DiagnosisException(DiagnosisErrorStatus._TYPE_NOT_FOUND)
+                        );//타입 조회 실패
 
         session.updateType(typeEntity);
 

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisQuickService.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisQuickService.java
@@ -46,7 +46,7 @@ public class DiagnosisQuickService {
         List<QuickKeyword> keywords = req.getKeywords();
         if (keywords == null || keywords.size() != 3) {
             throw new DiagnosisException(DiagnosisErrorStatus._INVALID_STEP);
-        }//잘못된 진단단계 예외
+        } //키워드 중간에 null이 들어감
 
         // 2) 응답 저장 (KW01~KW03)
         List<DiagnosisResponse> responses =
@@ -77,7 +77,7 @@ public class DiagnosisQuickService {
                 tastingNoteTypeRepository.findByCode(resultCode.name())
                         .orElseThrow(() ->
                                 new DiagnosisException(DiagnosisErrorStatus._TYPE_NOT_FOUND)
-                        );//타입 조회 실패
+                        );//타입 조회 실패 -> 결과는 잘 나왔는데 DB에 해당 타입이 없음 -> 서버문제
 
         session.updateType(typeEntity);
 

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisResultService.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisResultService.java
@@ -9,6 +9,8 @@ import com.example.SeaTea.domain.diagnosis.exception.DiagnosisErrorStatus;
 import com.example.SeaTea.domain.diagnosis.repository.DiagnosisSessionRepository;
 import com.example.SeaTea.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,17 +37,18 @@ public class DiagnosisResultService {
         return DiagnosisResultResponseDTO.from(type);
     }
 
-    // 나의 진단 결과 히스토리(완료된 세션 전체)
-    public List<DiagnosisHistoryResponseDTO> getMyHistory(Member member) {
-        List<DiagnosisSession> sessions = diagnosisSessionRepository
-                .findByMemberAndTypeIsNotNullOrderByCreatedAtDesc(member);
+    // 나의 진단 결과 히스토리(완료된 세션 전체) (슬라이스)
+    @Transactional(readOnly = true)
+    public Slice<DiagnosisHistoryResponseDTO> getMyHistory(
+            Member member,
+            Pageable pageable
+    ) {
+        Slice<DiagnosisSession> slice =
+                diagnosisSessionRepository.findByMemberAndTypeIsNotNullOrderByCreatedAtDesc(
+                        member,
+                        pageable
+                );
 
-        if (sessions.isEmpty()) {
-            throw new DiagnosisException(DiagnosisErrorStatus._NO_COMPLETED_DIAGNOSIS);
-        }
-
-        return sessions.stream()
-                .map(DiagnosisHistoryResponseDTO::from)
-                .toList();
+        return slice.map(DiagnosisHistoryResponseDTO::from);
     }
 }

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisResultService.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisResultService.java
@@ -1,0 +1,41 @@
+package com.example.SeaTea.domain.diagnosis.service;
+
+import com.example.SeaTea.domain.diagnosis.dto.response.DiagnosisHistoryResponseDTO;
+import com.example.SeaTea.domain.diagnosis.dto.response.DiagnosisResultResponseDTO;
+import com.example.SeaTea.domain.diagnosis.entity.DiagnosisSession;
+import com.example.SeaTea.domain.diagnosis.entity.TastingNoteType;
+import com.example.SeaTea.domain.diagnosis.repository.DiagnosisSessionRepository;
+import com.example.SeaTea.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiagnosisResultService {
+
+    private final DiagnosisSessionRepository diagnosisSessionRepository;
+
+    // 나의 최근 진단 결과 (완료된 세션 중 가장 최근 1건)
+    public DiagnosisResultResponseDTO getMyLatestResult(Member member) {
+        DiagnosisSession latest = diagnosisSessionRepository
+                .findTopByMemberAndTypeIsNotNullOrderByCreatedAtDesc(member)
+                .orElseThrow(() -> new IllegalStateException("완료된 진단 결과가 없습니다. memberId=" + member.getId()));
+
+        TastingNoteType type = latest.getType(); // type != null 보장
+        return DiagnosisResultResponseDTO.from(type);
+    }
+
+    // 나의 진단 결과 히스토리(완료된 세션 전체)
+    public List<DiagnosisHistoryResponseDTO> getMyHistory(Member member) {
+        List<DiagnosisSession> sessions = diagnosisSessionRepository
+                .findByMemberAndTypeIsNotNullOrderByCreatedAtDesc(member);
+
+        return sessions.stream()
+                .map(DiagnosisHistoryResponseDTO::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisResultService.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisResultService.java
@@ -28,10 +28,11 @@ public class DiagnosisResultService {
         DiagnosisSession latest = diagnosisSessionRepository
                 .findTopByMemberAndTypeIsNotNullOrderByCreatedAtDesc(member)
                 .orElseThrow(() -> new DiagnosisException(DiagnosisErrorStatus._NO_COMPLETED_DIAGNOSIS));
+                //진단을 한번도 안했거나, 세션은 있는데 아직 결과가 나오지 않았을 경우
 
         if (latest.getType() == null) {
             throw new DiagnosisException(DiagnosisErrorStatus._TYPE_NOT_FOUND);
-        }
+        }//타입 조회 실패 -> 결과는 잘 나왔는데 DB에 해당 타입이 없음 -> 서버문제
 
         TastingNoteType type = latest.getType(); // type != null 보장
         return DiagnosisResultResponseDTO.from(type);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 내 최신 진단 결과 조회 API 추가
  * 내 진단 기록 조회 API(페이징 지원) 추가
  * 진단 결과 및 기록 응답 포맷 추가(요약/상세 정보 포함)
* **버그 수정 / 개선**
  * 진단 입력 검증 강화(누락·잘못된 단계에 대해 예외 처리)
  * 결과/타입/세션 없음 등에 대해 명확한 도메인 오류 반환
<!-- end of auto-generated comment: release notes by coderabbit.ai -->