### PR TITLE
[Refactor] 진단 도메인 인증 연동 및 테스트 api 환경 정리

### DIFF
--- a/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
@@ -26,7 +26,7 @@ import org.springframework.data.domain.Sort;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/diagnosis")
 public class DiagnosisController {
 
     private final DiagnosisDetailService diagnosisDetailService;
@@ -40,7 +40,7 @@ public class DiagnosisController {
     }
 
     //상세 진단
-    @PostMapping("/diagnosis/detail")
+    @PostMapping("/detail")
     public ApiResponse<DiagnosisDetailResponseDTO> submitDetailDiagnosis(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody @Valid DiagnosisDetailRequestDTO req
@@ -53,7 +53,7 @@ public class DiagnosisController {
     }
 
     //간단 진단
-    @PostMapping("/diagnosis/quick")
+    @PostMapping("/quick")
     public ApiResponse<DiagnosisQuickResponseDTO> submitQuickDiagnosis(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody @Valid DiagnosisQuickRequestDTO req
@@ -67,7 +67,7 @@ public class DiagnosisController {
 
 
     //최신 진단결과 조회
-    @GetMapping("/diagnosis/me")
+    @GetMapping("/me")
     public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResult(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
@@ -79,7 +79,7 @@ public class DiagnosisController {
     }
 
     //과거 진단이력 조회 ( 슬라이스로 페이징 : 처음은 3개, 그 프론트에서 10개를 명시하면 됨.)
-    @GetMapping("/diagnosis/me/history")
+    @GetMapping("/me/history")
     public ApiResponse<Slice<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistory(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam(defaultValue = "0") int page,
@@ -97,60 +97,61 @@ public class DiagnosisController {
         );
         return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member, pageable));
     }
-
-    /// 포스트맨 테스트용 API : MemberId로 테스트
-
-    // 임시 테스트용: memberId로 멤버 조회 후 진단 제출
-    @PostMapping("/test/diagnosis/detail")
-    public ApiResponse<DiagnosisDetailResponseDTO> submitDetailDiagnosisTest(
-            @RequestParam Long memberId,
-            @RequestBody @Valid DiagnosisDetailRequestDTO req
-    ) {
-        System.out.println(">>> diagnosis detail test called"); //호출 확인용
-        Member member = findMemberOrThrow(memberId);
-
-        return ApiResponse.onSuccess(diagnosisDetailService.submitDetailDiagnosis(member, req));
-        //성공이면 200 OK, DTO를 JSON으로 반환
-    }
-
-    // 임시 테스트용: memberId로 멤버 조회 후 간단 진단 제출
-    @PostMapping("/test/diagnosis/quick")
-    public ApiResponse<DiagnosisQuickResponseDTO> submitQuickDiagnosisTest(
-            @RequestParam Long memberId,
-            @RequestBody @Valid DiagnosisQuickRequestDTO req
-    ) {
-        System.out.println(">>> diagnosis quick test called"); // 호출 확인용
-
-        Member member = findMemberOrThrow(memberId);
-
-        return ApiResponse.onSuccess(diagnosisQuickService.submitQuickDiagnosis(member, req));
-    }
-
-    // 임시 테스트용: memberId로 멤버 조회 후 최신 이력
-    @GetMapping("/test/diagnosis/me")
-    public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResultTest(
-            @RequestParam Long memberId
-    ) {
-        Member member = findMemberOrThrow(memberId);
-        return ApiResponse.onSuccess(diagnosisResultService.getMyLatestResult(member));
-    }
-
-    //임시 테스트용: memberId로 멤버 조회 후 과거 진단내역 조회 (슬라이스로 페이징)
-    @GetMapping("/test/diagnosis/me/history")
-    public ApiResponse<Slice<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistoryTest(
-            @RequestParam Long memberId,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "3") int size
-    ) {
-        Member member = findMemberOrThrow(memberId);
-
-        Pageable pageable = PageRequest.of(
-                page,
-                size,
-                Sort.by(Sort.Direction.DESC, "createdAt")
-        );
-
-        return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member, pageable));
-    }
+    /// ================== TEST ONLY ==================
+    /// ⚠️ 운영/배포 반영 금지: memberId로 타인 데이터 접근 가능
+    /// 필요 시 로컬에서만 잠깐 사용하고 바로 제거할 것
+    /// ===============================================
+//    // 임시 테스트용: memberId로 멤버 조회 후 진단 제출
+//    @PostMapping("/test/detail")
+//    public ApiResponse<DiagnosisDetailResponseDTO> submitDetailDiagnosisTest(
+//            @RequestParam Long memberId,
+//            @RequestBody @Valid DiagnosisDetailRequestDTO req
+//    ) {
+//        System.out.println(">>> diagnosis detail test called"); //호출 확인용
+//        Member member = findMemberOrThrow(memberId);
+//
+//        return ApiResponse.onSuccess(diagnosisDetailService.submitDetailDiagnosis(member, req));
+//        //성공이면 200 OK, DTO를 JSON으로 반환
+//    }
+//
+//    // 임시 테스트용: memberId로 멤버 조회 후 간단 진단 제출
+//    @PostMapping("/test/quick")
+//    public ApiResponse<DiagnosisQuickResponseDTO> submitQuickDiagnosisTest(
+//            @RequestParam Long memberId,
+//            @RequestBody @Valid DiagnosisQuickRequestDTO req
+//    ) {
+//        System.out.println(">>> diagnosis quick test called"); // 호출 확인용
+//
+//        Member member = findMemberOrThrow(memberId);
+//
+//        return ApiResponse.onSuccess(diagnosisQuickService.submitQuickDiagnosis(member, req));
+//    }
+//
+//    // 임시 테스트용: memberId로 멤버 조회 후 최신 이력
+//    @GetMapping("/test/me")
+//    public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResultTest(
+//            @RequestParam Long memberId
+//    ) {
+//        Member member = findMemberOrThrow(memberId);
+//        return ApiResponse.onSuccess(diagnosisResultService.getMyLatestResult(member));
+//    }
+//
+//    //임시 테스트용: memberId로 멤버 조회 후 과거 진단내역 조회 (슬라이스로 페이징)
+//    @GetMapping("/test/me/history")
+//    public ApiResponse<Slice<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistoryTest(
+//            @RequestParam Long memberId,
+//            @RequestParam(defaultValue = "0") int page,
+//            @RequestParam(defaultValue = "3") int size
+//    ) {
+//        Member member = findMemberOrThrow(memberId);
+//
+//        Pageable pageable = PageRequest.of(
+//                page,
+//                size,
+//                Sort.by(Sort.Direction.DESC, "createdAt")
+//        );
+//
+//        return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member, pageable));
+//    }
 
 }

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
@@ -16,6 +16,7 @@ import com.example.SeaTea.global.exception.GeneralException;
 import com.example.SeaTea.global.status.ErrorStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -24,7 +25,7 @@ import org.springframework.data.domain.Sort;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/diagnosis")
+@RequestMapping("/api")
 public class DiagnosisController {
 
     private final DiagnosisDetailService diagnosisDetailService;
@@ -37,8 +38,52 @@ public class DiagnosisController {
                 .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST));
     }
 
+    //상세 진단
+    @PostMapping("/diagnosis/detail")
+    public ApiResponse<DiagnosisDetailResponseDTO> submitDetailDiagnosis(
+            @AuthenticationPrincipal Member member,
+            @RequestBody @Valid DiagnosisDetailRequestDTO req
+    ) {
+        return ApiResponse.onSuccess(diagnosisDetailService.submitDetailDiagnosis(member, req));
+    }
+
+    //간단 진단
+    @PostMapping("/diagnosis/quick")
+    public ApiResponse<DiagnosisQuickResponseDTO> submitQuickDiagnosis(
+            @AuthenticationPrincipal Member member,
+            @RequestBody @Valid DiagnosisQuickRequestDTO req
+    ) {
+        return ApiResponse.onSuccess(diagnosisQuickService.submitQuickDiagnosis(member, req));
+    }
+
+
+    //최신 진단결과 조회
+    @GetMapping("/diagnosis/me")
+    public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResult(
+            @AuthenticationPrincipal Member member
+    ) {
+        return ApiResponse.onSuccess(diagnosisResultService.getMyLatestResult(member));
+    }
+
+    //과거 진단이력 조회
+    @GetMapping("/diagnosis/me/history")
+    public ApiResponse<Slice<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistory(
+            @AuthenticationPrincipal Member member,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "3") int size
+    ) {
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+        return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member, pageable));
+    }
+
+    /// 포스트맨 테스트용 API : MemberId로 테스트
+
     // 임시 테스트용: memberId로 멤버 조회 후 진단 제출
-    @PostMapping("/detail/test")
+    @PostMapping("/test/diagnosis/detail")
     public ApiResponse<DiagnosisDetailResponseDTO> submitDetailDiagnosisTest(
             @RequestParam Long memberId,
             @RequestBody @Valid DiagnosisDetailRequestDTO req
@@ -51,7 +96,7 @@ public class DiagnosisController {
     }
 
     // 임시 테스트용: memberId로 멤버 조회 후 간단 진단 제출
-    @PostMapping("/quick/test")
+    @PostMapping("/test/diagnosis/quick")
     public ApiResponse<DiagnosisQuickResponseDTO> submitQuickDiagnosisTest(
             @RequestParam Long memberId,
             @RequestBody @Valid DiagnosisQuickRequestDTO req
@@ -63,26 +108,8 @@ public class DiagnosisController {
         return ApiResponse.onSuccess(diagnosisQuickService.submitQuickDiagnosis(member, req));
     }
 
-//    // 나중에 인증 붙이면 이거로 교체
-//    @PostMapping("/detail")
-//    public ApiResponse<DiagnosisDetailResponseDTO> submitDetailDiagnosis(
-//            @AuthenticationPrincipal Member member,
-//            @RequestBody @Valid DiagnosisDetailRequestDTO req
-//    ) {
-//        return ApiResponse.onSuccess(diagnosisDetailService.submitDetailDiagnosis(member, req));
-//    }
-
-//    // 나중에 인증 붙이면 이거로 교체
-//    @PostMapping("/quick")
-//    public ApiResponse<DiagnosisQuickResponseDTO> submitQuickDiagnosis(
-//            @AuthenticationPrincipal Member member,
-//            @RequestBody @Valid DiagnosisQuickRequestDTO req
-//    ) {
-//        return ApiResponse.onSuccess(diagnosisQuickService.submitQuickDiagnosis(member, req));
-//    }
-
-    //내 최신 진단 조회
-    @GetMapping("/me/test")
+    // 임시 테스트용: memberId로 멤버 조회 후 최신 이력
+    @GetMapping("/test/diagnosis/me")
     public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResultTest(
             @RequestParam Long memberId
     ) {
@@ -90,12 +117,12 @@ public class DiagnosisController {
         return ApiResponse.onSuccess(diagnosisResultService.getMyLatestResult(member));
     }
 
-    //과거 진단내역 조회 (슬라이스로 페이징)
-    @GetMapping("/me/history/test")
+    //임시 테스트용: memberId로 멤버 조회 후 과거 진단내역 조회 (슬라이스로 페이징)
+    @GetMapping("/test/diagnosis/me/history")
     public ApiResponse<Slice<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistoryTest(
             @RequestParam Long memberId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "3") int size
     ) {
         Member member = findMemberOrThrow(memberId);
 
@@ -108,25 +135,4 @@ public class DiagnosisController {
         return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member, pageable));
     }
 
-    //나중에 인증붙으면 교체
-    // @GetMapping("/me")
-    // public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResult(
-    //         @AuthenticationPrincipal Member member
-    // ) {
-    //     return ApiResponse.onSuccess(diagnosisResultService.getMyLatestResult(member));
-    // }
-    //
-    // @GetMapping("/me/history")
-    // public ApiResponse<Slice<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistory(
-    //         @AuthenticationPrincipal Member member,
-    //         @RequestParam(defaultValue = "0") int page,
-    //         @RequestParam(defaultValue = "10") int size
-    // ) {
-    //     Pageable pageable = PageRequest.of(
-    //             page,
-    //             size,
-    //             Sort.by(Sort.Direction.DESC, "createdAt")
-    //     );
-    //     return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member, pageable));
-    // }
 }

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
@@ -12,6 +12,7 @@ import com.example.SeaTea.domain.diagnosis.service.DiagnosisResultService;
 import com.example.SeaTea.domain.member.entity.Member;
 import com.example.SeaTea.domain.member.repository.MemberRepository;
 import com.example.SeaTea.global.apiPayLoad.ApiResponse;
+import com.example.SeaTea.global.auth.CustomUserDetails;
 import com.example.SeaTea.global.exception.GeneralException;
 import com.example.SeaTea.global.status.ErrorStatus;
 import jakarta.validation.Valid;
@@ -41,18 +42,26 @@ public class DiagnosisController {
     //상세 진단
     @PostMapping("/diagnosis/detail")
     public ApiResponse<DiagnosisDetailResponseDTO> submitDetailDiagnosis(
-            @AuthenticationPrincipal Member member,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody @Valid DiagnosisDetailRequestDTO req
     ) {
+        if (customUserDetails == null) { //로그인안되면 COMMON401
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+        Member member = customUserDetails.getMember();
         return ApiResponse.onSuccess(diagnosisDetailService.submitDetailDiagnosis(member, req));
     }
 
     //간단 진단
     @PostMapping("/diagnosis/quick")
     public ApiResponse<DiagnosisQuickResponseDTO> submitQuickDiagnosis(
-            @AuthenticationPrincipal Member member,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody @Valid DiagnosisQuickRequestDTO req
     ) {
+        if (customUserDetails == null) { //로그인안되면 COMMON401
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+        Member member = customUserDetails.getMember();
         return ApiResponse.onSuccess(diagnosisQuickService.submitQuickDiagnosis(member, req));
     }
 
@@ -60,18 +69,27 @@ public class DiagnosisController {
     //최신 진단결과 조회
     @GetMapping("/diagnosis/me")
     public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResult(
-            @AuthenticationPrincipal Member member
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
+        if (customUserDetails == null) { //로그인안되면 COMMON401
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+        Member member = customUserDetails.getMember();
         return ApiResponse.onSuccess(diagnosisResultService.getMyLatestResult(member));
     }
 
-    //과거 진단이력 조회
+    //과거 진단이력 조회 ( 슬라이스로 페이징 : 처음은 3개, 그 프론트에서 10개를 명시하면 됨.)
     @GetMapping("/diagnosis/me/history")
     public ApiResponse<Slice<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistory(
-            @AuthenticationPrincipal Member member,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "3") int size
     ) {
+        if (customUserDetails == null) { //로그인안되면 COMMON401
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+        Member member = customUserDetails.getMember();
+
         Pageable pageable = PageRequest.of(
                 page,
                 size,

--- a/src/main/java/com/example/SeaTea/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/SeaTea/global/config/SecurityConfig.java
@@ -31,6 +31,9 @@ public class SecurityConfig {
       "/v3/api-docs/**",
       "/error",
 
+      //Diagnosis 테스트용 (로그인 전)
+      "/api/test/**",
+
       // 콘솔 로그에 favicon 제거
       "/favicon.ico"
   };

--- a/src/main/java/com/example/SeaTea/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/SeaTea/global/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
       "/error",
 
       //Diagnosis 테스트용 (로그인 전)
-      "/api/test/**",
+      "/api/diagnosis/test/**",
 
       // 콘솔 로그에 favicon 제거
       "/favicon.ico"


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

refactor/16-diagnosis-stabilization
## 🔑 주요 내용

- 주요 변경점 간단 요약
### 작업 내용
- 진단 API에 로그인 기반 인증 연동
- 로그인 / 비로그인 상태 접근 제어 분리
- 테스트용 API 경로 분리 및 시큐리티 설정 보완
- Postman 기반 진단 기능 전체 플로우 테스트 완료

### 테스트
- 로그인 성공 후 진단 step1 정상 동작 확인
- 비로그인 상태 접근 시 로그인 페이지 리다이렉트 확인
- 기존 테스트 API 정상 동작 확인

### 참고
- 프론트 연동 가능한 상태입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 진단 제출(상세/간편)과 개인 진단 결과 조회가 인증 기반으로 동작하도록 변경
  * 개인 진단 이력 조회 시 페이지네이션 지원

* **개선사항**
  * API 경로 구조 일부 단순화
  * 테스트용 진단 엔드포인트는 별도 경로로 인증 없이 이용 가능하도록 유지
<!-- end of auto-generated comment: release notes by coderabbit.ai -->