### PR TITLE
[FEAT] 타입별 공간조회 API 및 타입별 랜덤 공간 추천 API 구현

### DIFF
--- a/src/main/java/com/example/SeaTea/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/example/SeaTea/domain/place/controller/PlaceController.java
@@ -46,10 +46,10 @@ public class PlaceController {
         );
     }
 
-    //공간 추천
-    @GetMapping("/recommend")
-    @Operation(summary = "공간 추천", description = "휴식유형(tastingTypeCode)에 해당하는 공간을 커서 기반으로 추천합니다.")
-    public ApiResponse<SpaceListResponse> getRecommendedSpaces(
+    // 타입별 공간 목록 조회 (관리/검수/탐색 용도)
+    @GetMapping("/type")
+    @Operation(summary = "타입별 공간 목록 조회", description = "휴식유형(tastingTypeCode)에 해당하는 공간 목록을 커서 기반으로 조회합니다.")
+    public ApiResponse<SpaceListResponse> getSpacesByType(
         @Parameter(description = "휴식유형 코드 (예: SMOKY)")
         @RequestParam TastingNoteTypeCode tastingTypeCode,
         @Parameter(description = "위도 (거리 표시 시 필요)")
@@ -63,6 +63,23 @@ public class PlaceController {
     ) {
         return ApiResponse.onSuccess(
             placeQueryService.getRecommendedSpaces(tastingTypeCode.name(), lat, lng, size, cursor)
+        );
+    }
+
+    // 타입 내 랜덤 추천 3개 (사용자 노출용 추천)
+    // 현재는 기존 조회 로직을 재사용하여 size=3으로 제한합니다. (랜덤화는 서비스 로직에서 적용 권장)
+    @GetMapping("/recommend")
+    @Operation(summary = "공간 추천(랜덤 3개)", description = "휴식유형(tastingTypeCode)에 해당하는 공간 중 3개를 추천합니다.")
+    public ApiResponse<SpaceListResponse> recommend3Spaces(
+        @Parameter(description = "휴식유형 코드 (예: SMOKY)")
+        @RequestParam TastingNoteTypeCode tastingTypeCode,
+        @Parameter(description = "위도 (거리 표시 시 필요)")
+        @RequestParam(required = false) Double lat,
+        @Parameter(description = "경도 (거리 표시 시 필요)")
+        @RequestParam(required = false) Double lng
+    ) {
+        return ApiResponse.onSuccess(
+            placeQueryService.recommend3SpacesRandom(tastingTypeCode.name(), lat, lng)
         );
     }
 

--- a/src/main/java/com/example/SeaTea/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/example/SeaTea/domain/place/controller/PlaceController.java
@@ -67,7 +67,6 @@ public class PlaceController {
     }
 
     // 타입 내 랜덤 추천 3개 (사용자 노출용 추천)
-    // 현재는 기존 조회 로직을 재사용하여 size=3으로 제한합니다. (랜덤화는 서비스 로직에서 적용 권장)
     @GetMapping("/recommend")
     @Operation(summary = "공간 추천(랜덤 3개)", description = "휴식유형(tastingTypeCode)에 해당하는 공간 중 3개를 추천합니다.")
     public ApiResponse<SpaceListResponse> recommend3Spaces(

--- a/src/main/java/com/example/SeaTea/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/example/SeaTea/domain/place/controller/PlaceController.java
@@ -1,5 +1,7 @@
 package com.example.SeaTea.domain.place.controller;
 
+import com.example.SeaTea.domain.diagnosis.enums.TastingNoteTypeCode;
+
 import com.example.SeaTea.domain.place.dto.SpaceListResponse;
 import com.example.SeaTea.domain.place.service.PlaceQueryService;
 import com.example.SeaTea.domain.place.dto.SpaceDetailResponse;
@@ -41,6 +43,26 @@ public class PlaceController {
     ) {
         return ApiResponse.onSuccess(
             placeQueryService.getSpaces(lat, lng, q, size, cursor)
+        );
+    }
+
+    //공간 추천
+    @GetMapping("/recommend")
+    @Operation(summary = "공간 추천", description = "휴식유형(tastingTypeCode)에 해당하는 공간을 커서 기반으로 추천합니다.")
+    public ApiResponse<SpaceListResponse> getRecommendedSpaces(
+        @Parameter(description = "휴식유형 코드 (예: SMOKY)")
+        @RequestParam TastingNoteTypeCode tastingTypeCode,
+        @Parameter(description = "위도 (거리 표시 시 필요)")
+        @RequestParam(required = false) Double lat,
+        @Parameter(description = "경도 (거리 표시 시 필요)")
+        @RequestParam(required = false) Double lng,
+        @Parameter(description = "페이지 크기 (기본 20, 최대 100)")
+        @RequestParam(required = false) Integer size,
+        @Parameter(description = "커서 토큰 (응답의 nextCursor 그대로 전달)")
+        @RequestParam(required = false) String cursor
+    ) {
+        return ApiResponse.onSuccess(
+            placeQueryService.getRecommendedSpaces(tastingTypeCode.name(), lat, lng, size, cursor)
         );
     }
 

--- a/src/main/java/com/example/SeaTea/domain/place/dto/SpaceListResponse.java
+++ b/src/main/java/com/example/SeaTea/domain/place/dto/SpaceListResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class SpaceListResponse {
-    private final List<SpaceItem> items;
+    private final List<?> items;
     private final CursorInfo cursorInfo;
 
     @Getter
@@ -20,6 +20,20 @@ public class SpaceListResponse {
         private final Double lng;
         private final String thumbnailImageUrl;
         private final String address;
+        private final Long distanceMeters;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class SpaceItemWithDescription {//공간 추천용
+        private final Long spaceId;
+        private final String name;
+        private final String tastingTypeCode;
+        private final Double lat;
+        private final Double lng;
+        private final String thumbnailImageUrl;
+        private final String address;
+        private final String description;   //description 우선, note fallback
         private final Long distanceMeters;
     }
 

--- a/src/main/java/com/example/SeaTea/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/example/SeaTea/domain/place/repository/PlaceRepository.java
@@ -28,6 +28,8 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
         java.math.BigDecimal getLng();
         String getThumbnailImageUrl();
         String getAddress();
+        String getDescription();
+        String getNote();
         Double getDistanceMeters();
     }
 
@@ -41,6 +43,8 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
             p.lng as lng,
             p.thumbnail_image_url as thumbnailImageUrl,
             p.address as address,
+            p.description as description,
+            p.note as note,
             null as distanceMeters
         from place p
         left join tasting_note_type t on t.id = p.tasting_type_id
@@ -65,6 +69,8 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
                 p.lng as lng,
                 p.thumbnail_image_url as thumbnailImageUrl,
                 p.address as address,
+                p.description as description,
+                p.note as note,
                 ST_Distance_Sphere(point(p.lng, p.lat), point(:lng, :lat)) as distanceMeters
             from place p
             left join tasting_note_type t on t.id = p.tasting_type_id
@@ -94,6 +100,8 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
                 p.lng as lng,
                 p.thumbnail_image_url as thumbnailImageUrl,
                 p.address as address,
+                p.description as description,
+                p.note as note,
                 6371000 * 2 * asin(sqrt(
                     power(sin(radians(:lat - p.lat) / 2), 2) +
                     cos(radians(:lat)) * cos(radians(p.lat)) *

--- a/src/main/java/com/example/SeaTea/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/example/SeaTea/domain/place/repository/PlaceRepository.java
@@ -31,6 +31,29 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
         Double getDistanceMeters();
     }
 
+    // 타입(code)으로 장소 추천/검색 + keyset (distance 없이)
+    @Query(value = """
+        select
+            p.place_id as placeId,
+            p.name as name,
+            t.code as tastingTypeCode,
+            p.lat as lat,
+            p.lng as lng,
+            p.thumbnail_image_url as thumbnailImageUrl,
+            p.address as address,
+            null as distanceMeters
+        from place p
+        left join tasting_note_type t on t.id = p.tasting_type_id
+        where t.code = :tastingTypeCode
+          and (:lastId is null or p.place_id > :lastId)
+        order by p.place_id asc
+        limit :limit
+        """, nativeQuery = true)
+    List<PlaceDistanceView> findByTastingTypeWithCursor(@Param("tastingTypeCode") String tastingTypeCode,
+                                                       @Param("lastId") Long lastId,
+                                                       @Param("limit") int limit);
+
+
     // MySQL 거리 정렬 + keyset
     @Query(value = """
         select * from (

--- a/src/main/java/com/example/SeaTea/domain/place/status/SpaceErrorStatus.java
+++ b/src/main/java/com/example/SeaTea/domain/place/status/SpaceErrorStatus.java
@@ -9,8 +9,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum SpaceErrorStatus implements BaseErrorCode {
-    _INVALID_PARAMS(HttpStatus.BAD_REQUEST, "400", "위치 정보(lat,lng)가 올바르지 않습니다."),
-    _NOT_FOUND(HttpStatus.NOT_FOUND, "404", "공간을 찾을 수 없습니다.");
+    _INVALID_PARAMS(HttpStatus.BAD_REQUEST, "PLACE400", "위치 정보(lat,lng)가 올바르지 않습니다."),
+    _NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE404", "공간을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/SeaTea/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/SeaTea/global/exception/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 
 @Slf4j
 @RestControllerAdvice
@@ -94,6 +95,31 @@ public class GlobalExceptionHandler {
             reason.getCode(),
             reason.getMessage(),
             errorMessage // 구체적인 에러 사유를 데이터로 전달
+        ));
+  }
+
+  /**
+   * 3-1. 필수 RequestParam 누락
+   * 컨트롤러 메서드 호출 전에 발생합니다.
+   */
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<ApiResponse<Object>> handleMissingServletRequestParameter(
+      MissingServletRequestParameterException e, HttpServletRequest request) {
+
+    log.warn("[MissingRequestParam] Url: {}, Param: {}, Message: {}",
+        request.getRequestURI(), e.getParameterName(), e.getMessage());
+
+    ErrorReasonDTO reason = ErrorStatus._BAD_REQUEST.getReasonHttpStatus();
+
+    Map<String, Object> data = new LinkedHashMap<>();
+    data.put("missingParameter", e.getParameterName());
+
+    return ResponseEntity
+        .status(reason.getHttpStatus())
+        .body(ApiResponse.onFailure(
+            reason.getCode(),
+            reason.getMessage(),
+            data
         ));
   }
 


### PR DESCRIPTION
## 🌿 이슈 및 작업중인 브랜치
- feat/20-place-recommend

## 🔑 주요 내용
- 장소 도메인 에러코드 정리 및 필수 파라미터 누락 예외 처리 보완
- 휴식 유형(tastingTypeCode) 기준 타입별 공간 목록 조회 API 구현
- 휴식 유형 내 공간 3개를 랜덤으로 추천하는 공간 추천 API 구현
- 추천 API와 목록 조회 API의 역할 분리 (추천 / 탐색 용도 구분)

## 🧪 테스트
- Postman을 통해 타입별 공간 조회 API 정상 동작 확인
- 타입별 랜덤 공간 추천 API 호출 시 최대 3개의 공간이 랜덤으로 반환되는 것 확인
- 필수 파라미터 누락 및 잘못된 타입 코드에 대한 예외 응답 확인

## ✅ Check List
- [x] **Reviewers** 등록을 하셨나요?
- [x] **Assignees** 등록을 하셨나요?
- [x] **라벨(Label)** 등록을 하셨나요?
- [x] PR 머지 전 **CI가 정상적으로 동작하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공간 유형별 조회 API 추가(커서 기반 페이지네이션, 선택적 위치 기반 거리 포함)
  * 유형별 무작위 3개 공간 추천 API 추가(선택적 위치 기반 거리 포함)
  * 응답 항목에 설명(description) 및 노트(note) 포함

* **버그 수정**
  * 필수 요청 매개변수 누락 시 응답 개선 및 처리 추가
  * 공간 관련 오류 코드 값 표준화 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->