### PR TITLE
[FIX] Diagnosis API 안정화 및 Jackson 설정 임시 수정

### DIFF
--- a/src/main/java/com/example/SeaTea/global/config/JacksonConfig.java
+++ b/src/main/java/com/example/SeaTea/global/config/JacksonConfig.java
@@ -20,12 +20,12 @@ public class JacksonConfig {
     mapper.registerModule(new JavaTimeModule());
     mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-    // 보안 취약점 방지를 위한 최소한의 모듈만 등록
-    mapper.registerModules(
-        new CoreJackson2Module(),
-        new WebJackson2Module(),
-        new OAuth2ClientJackson2Module()
-    );
+//    // 보안 취약점 방지를 위한 최소한의 모듈만 등록
+//    mapper.registerModules(
+//        new CoreJackson2Module(),
+//        new WebJackson2Module(),
+//        new OAuth2ClientJackson2Module()
+//    );
     return mapper;
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,4 +56,4 @@ app:
   frontend-callback-url: ${FRONTEND_CALLBACK_URL}
 
 file:
-  upload-dir: C:${IMAGE_UPLOAD}
+  upload-dir: ${user.home}${IMAGE_UPLOAD}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: SeaTea
 
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE}
+    active: ${SPRING_PROFILES_ACTIVE:}
 
   datasource:
     url: ${DB_URL}


### PR DESCRIPTION
## 🌿 이슈 및 작업중인 브랜치
- refactor/16-diagnosis-stabilization-v2

## 🔑 주요 내용
- dev 최신 변경사항 병합
- Diagnosis API 토큰 기반 인증 흐름 확인
- JacksonConfig에서 Spring Security Jackson 모듈 전역 등록으로 인해
  요청 DTO에 `@class` 타입 메타데이터가 요구되는 문제 발생
- 프론트 테스트 진행을 위해 해당 설정 임시 주석 처리

## 🛠 변경 배경
- default typing 적용으로 JSON parse error 발생
- 요청 Body에 `@class`를 명시하지 않으면 역직렬화 실패
- 전역 ObjectMapper 설정을 분리하여 API 정상 동작하도록 조정

## ⚠️ 참고
- Security/OAuth2 직렬화가 필요한 경우 별도 ObjectMapper 사용 필요
- 해당 부분은 추후 보안 및 구조 관점에서 재정리 예정

## ✅ Check List
- [x] dev 브랜치 병합 완료
- [x] Diagnosis API 정상 동작 확인
- [x] 토큰 인증 없이 접근 시 401 확인
- [ ] CI 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타 작업**
  * 내부 보안 설정 구성 변경으로 인한 런타임 동작 수정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->