### PR TITLE
[REFACTOR] 진단 로직 안정화 및 Swagger 문서화 정리

### DIFF
--- a/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
@@ -15,6 +15,9 @@ import com.example.SeaTea.global.apiPayLoad.ApiResponse;
 import com.example.SeaTea.global.auth.service.CustomUserDetails;
 import com.example.SeaTea.global.exception.GeneralException;
 import com.example.SeaTea.global.status.ErrorStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,6 +27,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 
+@Tag(name = "Diagnosis", description = "진단(상세/간단) 및 결과 조회 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/diagnosis")
@@ -40,6 +44,7 @@ public class DiagnosisController {
     }
 
     //상세 진단
+    @Operation(summary = "상세 진단 제출", description = "Step1 또는 Step2 상세 진단을 제출합니다.")
     @PostMapping("/detail")
     public ApiResponse<DiagnosisDetailResponseDTO> submitDetailDiagnosis(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
@@ -53,6 +58,7 @@ public class DiagnosisController {
     }
 
     //간단 진단
+    @Operation(summary = "간단 진단 제출", description = "3개의 키워드를 기반으로 간단 진단을 수행합니다.")
     @PostMapping("/quick")
     public ApiResponse<DiagnosisQuickResponseDTO> submitQuickDiagnosis(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
@@ -67,6 +73,7 @@ public class DiagnosisController {
 
 
     //최신 진단결과 조회
+    @Operation(summary = "나의 최신 진단 결과 조회", description = "완료된 진단 중 가장 최근 결과를 조회합니다.")
     @GetMapping("/me")
     public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResult(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
@@ -79,10 +86,13 @@ public class DiagnosisController {
     }
 
     //과거 진단이력 조회 ( 슬라이스로 페이징 : 처음은 3개, 그 프론트에서 10개를 명시하면 됨.)
+    @Operation(summary = "나의 진단 이력 조회", description = "완료된 진단 이력을 페이지 단위로 조회합니다.")
     @GetMapping("/me/history")
     public ApiResponse<Slice<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistory(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @Parameter(description = "페이지 번호 (0부터 시작)")
             @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기")
             @RequestParam(defaultValue = "3") int size
     ) {
         if (customUserDetails == null) { //로그인안되면 COMMON401
@@ -97,61 +107,4 @@ public class DiagnosisController {
         );
         return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member, pageable));
     }
-    /// ================== TEST ONLY ==================
-    /// ⚠️ 운영/배포 반영 금지: memberId로 타인 데이터 접근 가능
-    /// 필요 시 로컬에서만 잠깐 사용하고 바로 제거할 것
-    /// ===============================================
-//    // 임시 테스트용: memberId로 멤버 조회 후 진단 제출
-//    @PostMapping("/test/detail")
-//    public ApiResponse<DiagnosisDetailResponseDTO> submitDetailDiagnosisTest(
-//            @RequestParam Long memberId,
-//            @RequestBody @Valid DiagnosisDetailRequestDTO req
-//    ) {
-//        System.out.println(">>> diagnosis detail test called"); //호출 확인용
-//        Member member = findMemberOrThrow(memberId);
-//
-//        return ApiResponse.onSuccess(diagnosisDetailService.submitDetailDiagnosis(member, req));
-//        //성공이면 200 OK, DTO를 JSON으로 반환
-//    }
-//
-//    // 임시 테스트용: memberId로 멤버 조회 후 간단 진단 제출
-//    @PostMapping("/test/quick")
-//    public ApiResponse<DiagnosisQuickResponseDTO> submitQuickDiagnosisTest(
-//            @RequestParam Long memberId,
-//            @RequestBody @Valid DiagnosisQuickRequestDTO req
-//    ) {
-//        System.out.println(">>> diagnosis quick test called"); // 호출 확인용
-//
-//        Member member = findMemberOrThrow(memberId);
-//
-//        return ApiResponse.onSuccess(diagnosisQuickService.submitQuickDiagnosis(member, req));
-//    }
-//
-//    // 임시 테스트용: memberId로 멤버 조회 후 최신 이력
-//    @GetMapping("/test/me")
-//    public ApiResponse<DiagnosisResultResponseDTO> getMyDiagnosisResultTest(
-//            @RequestParam Long memberId
-//    ) {
-//        Member member = findMemberOrThrow(memberId);
-//        return ApiResponse.onSuccess(diagnosisResultService.getMyLatestResult(member));
-//    }
-//
-//    //임시 테스트용: memberId로 멤버 조회 후 과거 진단내역 조회 (슬라이스로 페이징)
-//    @GetMapping("/test/me/history")
-//    public ApiResponse<Slice<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistoryTest(
-//            @RequestParam Long memberId,
-//            @RequestParam(defaultValue = "0") int page,
-//            @RequestParam(defaultValue = "3") int size
-//    ) {
-//        Member member = findMemberOrThrow(memberId);
-//
-//        Pageable pageable = PageRequest.of(
-//                page,
-//                size,
-//                Sort.by(Sort.Direction.DESC, "createdAt")
-//        );
-//
-//        return ApiResponse.onSuccess(diagnosisResultService.getMyHistory(member, pageable));
-//    }
-
 }

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisDetailConverter.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/converter/DiagnosisDetailConverter.java
@@ -1,24 +1,18 @@
 package com.example.SeaTea.domain.diagnosis.converter;
 
-import com.example.SeaTea.domain.diagnosis.exception.DiagnosisException;
-import com.example.SeaTea.domain.diagnosis.exception.DiagnosisErrorStatus;
 import com.example.SeaTea.domain.diagnosis.dto.request.DiagnosisDetailRequestDTO;
 import com.example.SeaTea.domain.diagnosis.entity.DiagnosisResponse;
 import com.example.SeaTea.domain.diagnosis.entity.DiagnosisSession;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class DiagnosisDetailConverter {
 
-    /** Step2 처리 시 DB에 저장된 Step1(Q1~Q4) 응답을 복원하기 위한 DTO */
-    public record Step1Answers(String q1, String q2, Integer q3, List<String> q4) {}
-
     public static List<DiagnosisResponse> fromStep1(
-            DiagnosisSession session, //엔터티
-            DiagnosisDetailRequestDTO req //DTO
-    ) { //응답 리스트 생성
+            DiagnosisSession session,
+            DiagnosisDetailRequestDTO req
+    ) {
         List<DiagnosisResponse> responses = new ArrayList<>();
 
         add(responses, session, "Q1", req.getQ1());
@@ -34,10 +28,9 @@ public class DiagnosisDetailConverter {
         return responses;
     }
 
-    //step2 요청값을 엔터티로 변환
     public static List<DiagnosisResponse> fromStep2(
-            DiagnosisSession session, //엔터티
-            DiagnosisDetailRequestDTO req //DTO
+            DiagnosisSession session,
+            DiagnosisDetailRequestDTO req
     ) {
         List<DiagnosisResponse> responses = new ArrayList<>();
 
@@ -49,47 +42,7 @@ public class DiagnosisDetailConverter {
         return responses;
     }
 
-    /**
-     * Step2 요청에는 q1~q4가 포함되지 않으므로, 세션에 저장된 Step1(Q1~Q4) 응답을 DB에서 읽어 복원한다.
-     * Q4는 저장 시 "ALONE_ANYONE" 처럼 '_'로 merge 되었으므로 split("_")로 되돌린다.
-     */
-    public static Step1Answers restoreStep1Answers(List<DiagnosisResponse> responses) {
-        String q1 = null;
-        String q2 = null;
-        Integer q3 = null;
-        List<String> q4 = null;
-
-        for (DiagnosisResponse r : responses) {
-            if (r.getItemCode() == null) continue;
-
-            switch (r.getItemCode()) {
-                case "Q1" -> q1 = r.getAnswerCode();
-                case "Q2" -> q2 = r.getAnswerCode();
-                case "Q3" -> {
-                    if (r.getAnswerCode() != null) {
-                        q3 = Integer.parseInt(r.getAnswerCode());
-                    }
-                }
-                case "Q4" -> {
-                    if (r.getAnswerCode() != null) {
-                        q4 = Arrays.asList(r.getAnswerCode().split("_"));
-                    }
-                }
-                default -> {
-                    // ignore
-                }
-            }
-        }
-
-        // Step1 응답 누락은 데이터 정합성 문제이므로 요청 오류로 처리
-        if (q1 == null || q2 == null || q3 == null || q4 == null || q4.isEmpty()) {
-            throw new DiagnosisException(DiagnosisErrorStatus._INVALID_STEP);
-        } //즉, step2요청이 들어왔을 때, DB에 step1 응답이 하나라도 누락되어 있으면 예외발생.
-
-        return new Step1Answers(q1, q2, q3, q4);
-    }
-
-    //Q4의 응답을 하나의 row에 담기 위함.
+    // Q4의 응답을 하나의 row에 담기 위함.
     private static String mergeQ4Answers(List<String> answers) {
         if (answers.size() == 1) {
             return answers.get(0);
@@ -109,7 +62,7 @@ public class DiagnosisDetailConverter {
     ) {
         if (answerCode == null) return;
 
-        list.add(DiagnosisResponse.builder() //엔터티 생성
+        list.add(DiagnosisResponse.builder()
                 .session(session)
                 .itemCode(itemCode)
                 .answerCode(answerCode)

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisDetailService.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisDetailService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.LinkedHashMap;
 
@@ -36,6 +37,9 @@ public class DiagnosisDetailService {
     private final DiagnosisSessionRepository diagnosisSessionRepository;
     private final DiagnosisResponseRepository diagnosisResponseRepository;
     private final TastingNoteTypeRepository tastingNoteTypeRepository;
+
+    /** Step2 처리 시 DB에 저장된 Step1(Q1~Q4) 응답을 복원하기 위한 DTO */
+    private record Step1Answers(String q1, String q2, Integer q3, List<String> q4) {}
 
     /**
      * [상세 진단 제출]
@@ -134,7 +138,7 @@ public class DiagnosisDetailService {
         // 3) Step1/Step2 점수 계산
         // Step2 요청에는 q1~q4가 포함되지 않으므로, DB에 저장된 Step1(Q1~Q4) 응답을 복원해서 Step1 점수를 계산한다.
         List<DiagnosisResponse> savedStep1Responses = diagnosisResponseRepository.findAllBySessionId(session.getId());
-        DiagnosisDetailConverter.Step1Answers step1 = DiagnosisDetailConverter.restoreStep1Answers(savedStep1Responses);
+        Step1Answers step1 = restoreStep1Answers(savedStep1Responses);
 
         Map<TastingNoteTypeCode, Integer> step1Scores = DiagnosisStep1.scoreStep1(
                 step1.q1(),
@@ -172,6 +176,48 @@ public class DiagnosisDetailService {
                 finalCodeStr,
                 session.getId()
         );
+    }
+    /**
+     * Step2 요청에는 q1~q4가 포함되지 않으므로, 세션에 저장된 Step1(Q1~Q4) 응답을 DB에서 읽어 복원한다.
+     * Q4는 저장 시 "ALONE_ANYONE" 처럼 '_'로 merge 되었으므로 split("_")로 되돌린다.
+     */
+    private Step1Answers restoreStep1Answers(List<DiagnosisResponse> responses) {
+        String q1 = null;
+        String q2 = null;
+        Integer q3 = null;
+        List<String> q4 = null;
+
+        for (DiagnosisResponse r : responses) {
+            if (r.getItemCode() == null) continue;
+
+            switch (r.getItemCode()) {
+                case "Q1" -> q1 = r.getAnswerCode();
+                case "Q2" -> q2 = r.getAnswerCode();
+                case "Q3" -> {
+                    if (r.getAnswerCode() != null) {
+                        try {
+                            q3 = Integer.parseInt(r.getAnswerCode());
+                        } catch (NumberFormatException e) {
+                            throw new DiagnosisException(DiagnosisErrorStatus._INVALID_STEP);
+                        }
+                    }
+                }
+                case "Q4" -> {
+                    if (r.getAnswerCode() != null) {
+                        q4 = Arrays.asList(r.getAnswerCode().split("_"));
+                    }
+                }
+                default -> {
+                    // ignore
+                }
+            }
+        }
+
+        if (q1 == null || q2 == null || q3 == null || q4 == null || q4.isEmpty()) {
+            throw new DiagnosisException(DiagnosisErrorStatus._INVALID_STEP);
+        }
+
+        return new Step1Answers(q1, q2, q3, q4);
     }
     /**
      * Step1/Step2 점수 맵을 합산해서 반환한다.

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisDetailService.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisDetailService.java
@@ -156,9 +156,9 @@ public class DiagnosisDetailService {
         log.warn("[STEP2 SCORES] {}", step2Scores);
         log.warn("[TOTAL SCORES] {}", totalScores);
 
-        // 4) Step1+Step2 점수로 최종 타입 결정
+        // 4) Step1+Step2 점수로 최종 타입 결정 (DTO 의존 제거: q3 값만 전달)
         TastingNoteTypeCode finalCode =
-                DiagnosisResultDecider.decideFinal(req, step1Scores, step2Scores);
+                DiagnosisResultDecider.decideFinal(step1.q3(), step1Scores, step2Scores);
 
         String finalCodeStr = finalCode.name();
 

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisDetailService.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisDetailService.java
@@ -32,6 +32,7 @@ import java.util.LinkedHashMap;
 @RequiredArgsConstructor
 @Transactional
 @Slf4j
+//상세 조회용 서비스
 public class DiagnosisDetailService {
 
     private final DiagnosisSessionRepository diagnosisSessionRepository;

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisQuickService.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisQuickService.java
@@ -26,6 +26,7 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 @Transactional
+//간단 조회용
 public class DiagnosisQuickService {
 
     private final DiagnosisSessionRepository diagnosisSessionRepository;

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisResultService.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisResultService.java
@@ -19,6 +19,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+//결과 조회용
 public class DiagnosisResultService {
 
     private final DiagnosisSessionRepository diagnosisSessionRepository;


### PR DESCRIPTION
## 🌿 이슈 및 작업중인 브랜치
- refactor/16-diagnosis-stabilization-v3

## 🔑 주요 내용

### 1. 상세진단 로직 구조 개선
- Step1 복원 로직을 Converter → Service로 이동
- Converter는 DTO → Entity 변환 역할만 수행하도록 책임 분리 (SRP 개선)

### 2. Decider DTO 의존 제거
- DiagnosisResultDecider에서 Request DTO 의존 제거
- q3 값만 전달하도록 수정하여 도메인 로직 순수화

### 3. Swagger 문서화 정리
- DiagnosisController에 @Tag 추가
- 각 API에 @Operation 설명 추가
- history API에 @Parameter 설명 추가

## ✅ 변경 요약
- 단일 책임 원칙(SRP) 개선
- 도메인 로직 레이어 경계 명확화
- Swagger 가독성 개선

## Check List
- [ ] Reviewers 등록
- [ ] Assignees 등록
- [ ] Label 등록
- [ ] CI 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 진단 API에 대한 상세한 OpenAPI 문서화 추가
  * 각 엔드포인트의 기능과 매개변수에 대한 설명 명시
  * 상세 진단 제출, 간단 진단 제출, 진단 결과 조회, 진단 이력 조회 기능 상세 기록

<!-- end of auto-generated comment: release notes by coderabbit.ai -->