### PR TITLE
[REFACTOR] 진단 이력 조회 기본 페이지 크기 10으로 변경

### DIFF
--- a/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/controller/DiagnosisController.java
@@ -85,7 +85,7 @@ public class DiagnosisController {
         return ApiResponse.onSuccess(diagnosisResultService.getMyLatestResult(member));
     }
 
-    //과거 진단이력 조회 ( 슬라이스로 페이징 : 처음은 3개, 그 프론트에서 10개를 명시하면 됨.)
+    //과거 진단이력 조회 ( 슬라이스로 페이징 : 페이징은 10개씩 하되, 처음 노출은 3개만..)
     @Operation(summary = "나의 진단 이력 조회", description = "완료된 진단 이력을 페이지 단위로 조회합니다.")
     @GetMapping("/me/history")
     public ApiResponse<Slice<DiagnosisHistoryResponseDTO>> getMyDiagnosisHistory(
@@ -93,7 +93,7 @@ public class DiagnosisController {
             @Parameter(description = "페이지 번호 (0부터 시작)")
             @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기")
-            @RequestParam(defaultValue = "3") int size
+            @RequestParam(defaultValue = "10") int size
     ) {
         if (customUserDetails == null) { //로그인안되면 COMMON401
             throw new GeneralException(ErrorStatus._UNAUTHORIZED);


### PR DESCRIPTION
## 🌿 이슈 및 작업중인 브랜치
- refactor/16-history-paging-policy

## 🔑 주요 내용

### 1. 진단 이력 조회 페이징 정책 변경
- history API 기본 page size를 3 → 10으로 수정
- API는 10개 단위로 조회하도록 통일

### 2. 화면 노출 정책 변경
- 첫 화면에서는 프론트에서 상위 3개만 노출
- 더보기/무한스크롤 시 나머지 데이터 및 다음 페이지 append

## ✅ 변경 요약
- page/size 혼합 사용 시 발생 가능한 데이터 누락 문제 제거
- API 구조 단순화
- 무한스크롤 구조 안정화

## Check List
- [ ] Reviewers 등록
- [ ] Assignees 등록
- [ ] Label 등록
- [ ] CI 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 내 히스토리 조회의 기본 페이지 크기를 증가시켰습니다. 한 화면에 표시되는 히스토리 항목 개수가 늘어나 사용자가 더 많은 항목을 한눈에 확인할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->