### PR TITLE
[FEAT] 회원탈퇴 시 진단 내역 소프트 딜리트 및 조회 제외 처리

### DIFF
--- a/src/main/java/com/example/SeaTea/domain/diagnosis/repository/DiagnosisResponseRepository.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/repository/DiagnosisResponseRepository.java
@@ -2,9 +2,25 @@ package com.example.SeaTea.domain.diagnosis.repository;
 
 import com.example.SeaTea.domain.diagnosis.entity.DiagnosisResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface DiagnosisResponseRepository extends JpaRepository<DiagnosisResponse, Long> {
     List<DiagnosisResponse> findAllBySessionId(Long sessionId);
+
+    //소프트 딜리트 -> session으로 조인한뒤 업데이트
+    @Modifying
+    @Transactional
+    @Query(value = """
+      UPDATE diagnosis_response dr
+      JOIN diagnosis_session ds ON dr.session_id = ds.id
+      SET dr.deleted_at = :now
+      WHERE ds.member_id = :memberId
+        AND dr.deleted_at IS NULL
+      """, nativeQuery = true)
+    int softDeleteByMemberId(Long memberId, LocalDateTime now);
 }

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/repository/DiagnosisSessionRepository.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/repository/DiagnosisSessionRepository.java
@@ -6,7 +6,12 @@ import com.example.SeaTea.domain.member.entity.Member;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,6 +23,23 @@ public interface DiagnosisSessionRepository extends JpaRepository<DiagnosisSessi
     // 나의 최신 진단 결과 1건 조회 (완료된 세션 중 최신)
     Optional<DiagnosisSession> findTopByMemberAndTypeIsNotNullOrderByCreatedAtDesc(Member member);
 
+    // 나의 최신 진단 결과 1건 조회 (완료된 세션 중 최신) - soft delete 제외
+    Optional<DiagnosisSession> findTopByMemberAndDeletedAtIsNullAndTypeIsNotNullOrderByCreatedAtDesc(Member member);
+
     // 나의 진단 히스토리 조회 (완료된 세션 전체, 최신순)
     Slice<DiagnosisSession> findByMemberAndTypeIsNotNullOrderByCreatedAtDesc(Member member, Pageable pageable);
+
+    // 나의 진단 히스토리 조회 (완료된 세션 전체, 최신순) - soft delete 제외
+    Slice<DiagnosisSession> findByMemberAndDeletedAtIsNullAndTypeIsNotNullOrderByCreatedAtDesc(Member member, Pageable pageable);
+
+    //소프트 딜리트
+    @Modifying
+    @Transactional
+    @Query(value = """
+      UPDATE diagnosis_session
+      SET deleted_at = :now
+      WHERE member_id = :memberId
+        AND deleted_at IS NULL
+      """, nativeQuery = true)
+    int softDeleteByMemberId(@Param("memberId") Long memberId, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisResultService.java
+++ b/src/main/java/com/example/SeaTea/domain/diagnosis/service/DiagnosisResultService.java
@@ -27,7 +27,7 @@ public class DiagnosisResultService {
     // 나의 최근 진단 결과 (완료된 세션 중 가장 최근 1건)
     public DiagnosisResultResponseDTO getMyLatestResult(Member member) {
         DiagnosisSession latest = diagnosisSessionRepository
-                .findTopByMemberAndTypeIsNotNullOrderByCreatedAtDesc(member)
+                .findTopByMemberAndDeletedAtIsNullAndTypeIsNotNullOrderByCreatedAtDesc(member)
                 .orElseThrow(() -> new DiagnosisException(DiagnosisErrorStatus._NO_COMPLETED_DIAGNOSIS));
                 //진단을 한번도 안했거나, 세션은 있는데 아직 결과가 나오지 않았을 경우
 
@@ -46,7 +46,7 @@ public class DiagnosisResultService {
             Pageable pageable
     ) {
         Slice<DiagnosisSession> slice =
-                diagnosisSessionRepository.findByMemberAndTypeIsNotNullOrderByCreatedAtDesc(
+                diagnosisSessionRepository.findByMemberAndDeletedAtIsNullAndTypeIsNotNullOrderByCreatedAtDesc(
                         member,
                         pageable
                 );

--- a/src/main/java/com/example/SeaTea/domain/member/scheduler/MemberBatchScheduler.java
+++ b/src/main/java/com/example/SeaTea/domain/member/scheduler/MemberBatchScheduler.java
@@ -27,7 +27,7 @@ public class MemberBatchScheduler {
 
     try {
       memberRepository.deleteByDeletedAtBefore(threshold);
-      log.info("30일 경과 탈퇴 회원 데이터 정리 완료 (기준일: {})", threshold);
+      log.info("14일 경과 탈퇴 회원 데이터 정리 완료 (기준일: {})", threshold);
     } catch (Exception e) {
       log.error("탈퇴 회원 데이터 정리 중 오류 발생: {}", e.getMessage());
     }


### PR DESCRIPTION
## 🌱 이슈 및 작업중인 브랜치

- feat/16-feat-withdraw-auto-cleanup

---

## 🔑 주요 내용

### 1️⃣ 회원탈퇴 시 진단 내역 Soft Delete 처리
- withdraw 로직에 diagnosis_response, diagnosis_session soft delete 추가
- 탈퇴 시 deleted_at 컬럼 업데이트

### 2️⃣ 진단 조회 API에서 Soft Delete 데이터 제외
- getMyLatestResult()
- getMyHistory()

→ deletedAtIsNull 조건 추가하여 탈퇴된 진단 세션 조회되지 않도록 수정

---

## 📌 변경 요약

- 진단 응답 → 진단 세션 순으로 soft delete 처리
- DiagnosisSessionRepository에 deletedAtIsNull 조건 메서드 추가
- 탈퇴 후 진단내역 조회 시 빈 결과 반환되도록 개선

---

## ✅ Check List

- [x] Reviewers 등록
- [ ] Assignees 등록
- [ ] Label 등록
- [ ] CI 정상 작동 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 회원 탈퇴 시 연관된 모든 진단 데이터가 안전하게 정리됩니다.
  * 삭제된 기록이 진단 결과 조회에서 정상적으로 제외됩니다.
  * 삭제된 진단 세션이 마이페이지 이력에서 더 이상 표시되지 않습니다.

* **기타 변경**
  * 회원 탈퇴 후 데이터 보관 기간이 30일에서 14일로 단축되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->