### PR TITLE
[FEAT] 토큰 만료 시 업데이트 api 설계

### DIFF
--- a/src/main/java/com/example/SeaTea/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/SeaTea/domain/member/controller/MemberController.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -204,6 +205,16 @@ public class MemberController {
     return ApiResponse.onSuccess(result);
   }
 
+  @PostMapping("/users/reissue")
+  public ApiResponse<MemberResDTO.TokenDTO> reissue(
+      @CookieValue(name = "refreshToken", required = false) String refreshToken,
+      HttpServletResponse response
+  ) {
+    String newAccessToken = memberCommandService.reissue(refreshToken, response);
+
+    // 응답 규격에 맞는 DTO 생성 (accessToken만 담아서 반환)
+    return ApiResponse.onSuccess(MemberConverter.toTokenDTO(newAccessToken));
+  }
 
   @DeleteMapping("/users/delete")
   public ApiResponse<String> withdraw(

--- a/src/main/java/com/example/SeaTea/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/SeaTea/domain/member/converter/MemberConverter.java
@@ -87,14 +87,14 @@ public class MemberConverter {
         .profileImageUrl(member.getProfile_image())
         .role(member.getRole())
         .savedSpaceCount(savedCount)
-        .currentType(toTastingTypeDTO(type)) // ✅ 유형 변환 호출
+        .currentType(toTastingTypeDTO(type)) // 유형 변환 호출
         .createdAt(member.getCreatedAt())
         .updatedAt(member.getUpdatedAt())
         .build();
   }
 
   private static MemberResDTO.TastingTypeDTO toTastingTypeDTO(TastingNoteType type) {
-    if (type == null) return null; // ✅ 진단 전이면 null 반환
+    if (type == null) return null; // 진단 전이면 null 반환
 
     return MemberResDTO.TastingTypeDTO.builder()
         .id(type.getId())
@@ -104,6 +104,12 @@ public class MemberConverter {
         .description(type.getDescription())
         .imageUrl(type.getImageUrl())
         .createdAt(type.getCreatedAt())
+        .build();
+  }
+
+  public static MemberResDTO.TokenDTO toTokenDTO(String accessToken) {
+    return MemberResDTO.TokenDTO.builder()
+        .accessToken(accessToken)
         .build();
   }
 }

--- a/src/main/java/com/example/SeaTea/domain/member/dto/response/MemberResDTO.java
+++ b/src/main/java/com/example/SeaTea/domain/member/dto/response/MemberResDTO.java
@@ -88,4 +88,11 @@ public class MemberResDTO {
       String imageUrl,
       LocalDateTime createdAt
   ) {}
+
+  // refresh 토큰으로 토큰 업데이트
+  @Builder
+  public record TokenDTO(
+      @Schema(description = "새로 발급된 Access Token")
+      String accessToken
+  ){}
 }

--- a/src/main/java/com/example/SeaTea/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/example/SeaTea/domain/member/service/command/MemberCommandService.java
@@ -3,6 +3,7 @@ package com.example.SeaTea.domain.member.service.command;
 import com.example.SeaTea.domain.member.dto.request.MemberReqDTO;
 import com.example.SeaTea.domain.member.dto.response.MemberResDTO;
 import com.example.SeaTea.domain.member.entity.Member;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface MemberCommandService {
 
@@ -21,4 +22,7 @@ public interface MemberCommandService {
 
   // 탈퇴 메서드
   void withdraw(Member member);
+
+  // 토큰 재발급
+  String reissue(String refreshToken, HttpServletResponse response);
 }

--- a/src/main/java/com/example/SeaTea/global/auth/entity/JwtTokenProvider.java
+++ b/src/main/java/com/example/SeaTea/global/auth/entity/JwtTokenProvider.java
@@ -79,6 +79,7 @@ public class JwtTokenProvider {
 
     return Jwts.builder()
         .setSubject(String.valueOf(userDetails.getMember().getId()))
+        .claim("role", userDetails.getMember().getRole().name())
         .setIssuedAt(new Date())
         .setExpiration(new Date(System.currentTimeMillis() + refreshTokenValidityInMilliseconds))
         .signWith(key, SignatureAlgorithm.HS256)

--- a/src/main/java/com/example/SeaTea/global/auth/exception/JwtExceptionFilter.java
+++ b/src/main/java/com/example/SeaTea/global/auth/exception/JwtExceptionFilter.java
@@ -1,18 +1,22 @@
 package com.example.SeaTea.global.auth.exception;
 
+import com.example.SeaTea.domain.member.exception.MemberException;
 import com.example.SeaTea.domain.member.exception.code.MemberErrorCode;
 import com.example.SeaTea.global.apiPayLoad.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import io.jsonwebtoken.JwtException;
 import java.io.IOException;
 
+@Component
 @RequiredArgsConstructor
 public class JwtExceptionFilter extends OncePerRequestFilter {
   private final ObjectMapper objectMapper;
@@ -23,18 +27,24 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
     try {
       // 다음 필터(JwtAuthenticationFilter) 실행
       filterChain.doFilter(request, response);
-    } catch (JwtException e) {
-      // JWT 관련 에러가 던져지면 캐치해서 응답 생성
-      setErrorResponse(response, e.getMessage());
+    } catch (MemberException e) {
+      // 우리가 정의한 에러 코드 활용
+      setErrorResponse(response, e.getCode().toString(), e.getMessage());
+    } catch (ExpiredJwtException e) {
+      // 토큰 만료
+      setErrorResponse(response, MemberErrorCode._JWT_WRONG.getCode(), "토큰이 만료되었습니다.");
+    } catch (JwtException | IllegalArgumentException e) {
+      // 그 외 JWT 관련 오류
+      setErrorResponse(response, MemberErrorCode._JWT_WRONG.getCode(), MemberErrorCode._JWT_WRONG.getMessage());
     }
   }
 
-  private void setErrorResponse(HttpServletResponse response, String message) throws IOException {
+  private void setErrorResponse(HttpServletResponse response, String code, String message) throws IOException {
     response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     response.setCharacterEncoding("UTF-8");
 
-    ApiResponse<Object> errorResponse = ApiResponse.onFailure(MemberErrorCode._JWT_WRONG.getCode(), MemberErrorCode._JWT_WRONG.getMessage() , null);
+    ApiResponse<Object> errorResponse = ApiResponse.onFailure(code, message, null);
 
     objectMapper.writeValue(response.getWriter(), errorResponse);
   }

--- a/src/main/java/com/example/SeaTea/global/auth/exception/JwtExceptionFilter.java
+++ b/src/main/java/com/example/SeaTea/global/auth/exception/JwtExceptionFilter.java
@@ -32,10 +32,10 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
       setErrorResponse(response, e.getCode().getReason().getCode(), e.getCode().getReason().getMessage());
     } catch (ExpiredJwtException e) {
       // 토큰 만료
-      setErrorResponse(response, MemberErrorCode._JWT_WRONG.getCode(), "토큰이 만료되었습니다.");
+      setErrorResponse(response, MemberErrorCode._JWT_WRONG.getReason().getCode(), "토큰이 만료되었습니다.");
     } catch (JwtException | IllegalArgumentException e) {
       // 그 외 JWT 관련 오류
-      setErrorResponse(response, MemberErrorCode._JWT_WRONG.getCode(), MemberErrorCode._JWT_WRONG.getMessage());
+      setErrorResponse(response, MemberErrorCode._JWT_WRONG.getReason().getCode(), MemberErrorCode._JWT_WRONG.getReason().getMessage());
     }
   }
 

--- a/src/main/java/com/example/SeaTea/global/auth/exception/JwtExceptionFilter.java
+++ b/src/main/java/com/example/SeaTea/global/auth/exception/JwtExceptionFilter.java
@@ -11,10 +11,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import io.jsonwebtoken.JwtException;
 import java.io.IOException;
 
+@Component
 @RequiredArgsConstructor
 public class JwtExceptionFilter extends OncePerRequestFilter {
   private final ObjectMapper objectMapper;

--- a/src/main/java/com/example/SeaTea/global/auth/exception/JwtExceptionFilter.java
+++ b/src/main/java/com/example/SeaTea/global/auth/exception/JwtExceptionFilter.java
@@ -11,12 +11,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import io.jsonwebtoken.JwtException;
 import java.io.IOException;
 
-@Component
 @RequiredArgsConstructor
 public class JwtExceptionFilter extends OncePerRequestFilter {
   private final ObjectMapper objectMapper;
@@ -29,7 +27,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
       filterChain.doFilter(request, response);
     } catch (MemberException e) {
       // 우리가 정의한 에러 코드 활용
-      setErrorResponse(response, e.getCode().toString(), e.getMessage());
+      setErrorResponse(response, e.getCode().getReason().getCode(), e.getCode().getReason().getMessage());
     } catch (ExpiredJwtException e) {
       // 토큰 만료
       setErrorResponse(response, MemberErrorCode._JWT_WRONG.getCode(), "토큰이 만료되었습니다.");

--- a/src/main/java/com/example/SeaTea/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/SeaTea/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.SeaTea.global.auth.entity.JsonLoginFilter;
 import com.example.SeaTea.global.auth.Kakao.KakaoOAuth2UserService;
 import com.example.SeaTea.global.auth.entity.JwtAuthenticationFilter;
 import com.example.SeaTea.global.auth.entity.JwtTokenProvider;
+import com.example.SeaTea.global.auth.exception.JwtExceptionFilter;
 import com.example.SeaTea.global.auth.repository.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.example.SeaTea.global.config.handler.CustomAccessDeniedHandler;
 import com.example.SeaTea.global.config.handler.CustomAuthenticationEntryPoint;
@@ -40,6 +41,7 @@ public class SecurityConfig {
   private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
   private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint; // 401 에러
   private final CustomAccessDeniedHandler customAccessDeniedHandler; // 403 에러
+  private final JwtExceptionFilter jwtExceptionFilter;
 
   private final String[] allowUris = {
       "/api/login",
@@ -133,10 +135,14 @@ public class SecurityConfig {
             .accessDeniedHandler(customAccessDeniedHandler)
         )
 
+        // JWT 인증 필터 등록
         .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
 
-        // 커스텀 JSON 필터를 UsernamePasswordAuthenticationFilter 위치에 추가
-        .addFilterAt(jsonLoginFilter(), org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class)
+        // 예외 처리 필터
+        .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+
+        // 커스텀 JSON 필터 등록
+        .addFilterAt(jsonLoginFilter(), UsernamePasswordAuthenticationFilter.class)
 
         // CORS 설정
         .cors(cors -> cors.configurationSource(corsConfigurationSource));

--- a/src/main/java/com/example/SeaTea/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/SeaTea/global/config/SecurityConfig.java
@@ -53,6 +53,9 @@ public class SecurityConfig {
       "/api/users/me",
       "/api/images/uploads/**",
 
+      // 토큰 재발급 허용
+      "/api/users/reissue",
+
       // api 연동 확인할 때만 선택적으로 주석 풀어서 하기(주석 풀면 인증 없이 /api/** 모든 접근 가능)
 //      "/api/**",
 


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- feat/17-social-login

## 🔑 주요 내용

- 토큰 만료 시 업데이트 api 설계
- 토큰 관련 예외 처리 설정

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 쿠키 기반 리프레시 토큰을 받아 액세스 토큰을 재발급하는 신규 엔드포인트 추가 — 재발급된 액세스 토큰을 반환합니다.
  * 재발급 시 리프레시 토큰 회전 및 쿠키 갱신으로 보안 강화.

* **개선 사항**
  * JWT 관련 예외 처리 범위 확대 및 일관된 오류 응답 제공.
  * 인증 필터 체인에 예외 처리 필터를 추가해 오류 처리 순서와 안정성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->