### PR TITLE
[FIX] 이미지 업로드 api 토큰 인증 없이 가능하게 처리 및 예외 처리

### DIFF
--- a/src/main/java/com/example/SeaTea/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/SeaTea/domain/member/converter/MemberConverter.java
@@ -40,7 +40,7 @@ public class MemberConverter {
         .password(password)
         .role(role)
         .nickname(dto.nickname())
-//        .profile_image(dto.profile_image())
+        .profile_image(dto.profile_url())
         .build();
   }
 

--- a/src/main/java/com/example/SeaTea/domain/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/com/example/SeaTea/domain/member/exception/code/MemberErrorCode.java
@@ -23,6 +23,7 @@ public enum MemberErrorCode implements BaseErrorCode {
   _INVALID_FILENAME(HttpStatus.BAD_REQUEST, "MEMBER409", "유효하지 않은 파일명입니다."),
   _UNALLOWED_FILENAME(HttpStatus.BAD_REQUEST, "MEMBER410", "허용되지 않은 파일 형식입니다."),
   _ACCESS_DENIED(HttpStatus.FORBIDDEN, "MEMBER411", "접근 권한이 없습니다."),
+  _FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "MEMBER412", "이미지의 크기가 너무 큽니다."),
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/example/SeaTea/domain/member/service/command/ImageServiceImpl.java
+++ b/src/main/java/com/example/SeaTea/domain/member/service/command/ImageServiceImpl.java
@@ -44,6 +44,17 @@ public class ImageServiceImpl implements ImageService {
       if (!allowedExtensions.contains(extension.toLowerCase())) {
         throw new MemberException(MemberErrorCode._UNALLOWED_FILENAME);
       }
+
+      // 파일 비어있는지 체크
+      if (file.isEmpty()) {
+        throw new MemberException(MemberErrorCode._FILE_EMPTY);
+      }
+
+      // 파일 크기 제한 5MB
+      if (file.getSize() > 5 * 1024 * 1024) {
+        throw new MemberException(MemberErrorCode._FILE_TOO_LARGE);
+      }
+
       String contentType = file.getContentType();
       if (contentType == null || !allowedContentTypes.contains(contentType.toLowerCase())) {
         throw new MemberException(MemberErrorCode._UNALLOWED_FILENAME);

--- a/src/main/java/com/example/SeaTea/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/SeaTea/domain/member/service/command/MemberCommandServiceImpl.java
@@ -14,7 +14,6 @@ import com.example.SeaTea.global.auth.repository.RefreshTokenRepository;
 import com.example.SeaTea.domain.diagnosis.repository.DiagnosisResponseRepository;
 import com.example.SeaTea.domain.diagnosis.repository.DiagnosisSessionRepository;
 import com.example.SeaTea.global.auth.service.CustomUserDetails;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -116,7 +115,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     // 기존 파일 삭제
     String oldImageUrl = realMember.getProfile_image();
-    if (oldImageUrl != null && !oldImageUrl.isEmpty()) {
+    if (oldImageUrl != null && !oldImageUrl.equals(dto.profileImageUrl())) {
       imageService.delete(oldImageUrl);
     }
 

--- a/src/main/java/com/example/SeaTea/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/SeaTea/global/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
       "/v3/api-docs/**",
       "/error",
       "/api/users/me",
+      "/api/upload/profile/image",
       "/api/images/uploads/**",
       "api/check/nickname",
       "api/check/email",


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- feat/17-social-login

## 🔑 주요 내용

- 이미지 업로드 api 토큰 인증 없이 가능하게 처리
- 이미지 업로드 예외 처리(크기 제한)

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 프로필 이미지 업로드 시 파일 크기 제한(5MB) 및 빈 파일 검증 추가
- 프로필 이미지 업데이트 시 URL이 변경되지 않은 경우 불필요한 파일 삭제 방지

## New Features
- 프로필 이미지 업로드 엔드포인트 인증 없이 접근 가능하도록 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->